### PR TITLE
Make backups schedule configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,15 +117,6 @@ RUN touch /var/log/duply.log && \
     chmod a+rw /var/log/duply* && \
     chown -R minecraft:minecraft /home/minecraft/.duply
 
-USER minecraft
-
-RUN (crontab -l ; echo "15 08 */7 * * /usr/bin/duply minecraft purgeAuto --force --allow-source-mismatch 2> /var/log/duply.err 1> /var/log/duply.log") | sort - | uniq - | crontab - && \
-    (crontab -l ; echo "0 * * * * /usr/bin/duply minecraft backup now --allow-source-mismatch 2> /var/log/duply.error 1> /var/log/duply.log") | sort - | uniq - | crontab - && \
-    (crontab -l ; echo "30 05 * * * /usr/bin/duply minecraft full now --allow-source-mismatch 2> /var/log/duply.error 1> /var/log/duply.log") | sort - | uniq - | crontab - && \
-    echo "Crontab prepared"
-
-USER root
-
 # ----------------------------------------------------------------------------------------------------------------------
 
 FROM backup AS prepare
@@ -149,6 +140,7 @@ RUN mv -u /minecraft/server /minecraft/server-init && \
     ln -sf /minecraft/tools/minecraft.sh /usr/bin/minecraft
 
 COPY scripts/parts /minecraft/scripts
+COPY scripts/setup-cron.sh /minecraft/scripts/setup-cron.sh
 COPY scripts/start.sh /minecraft/start.sh
 
 RUN chown -R minecraft:minecraft /minecraft && \

--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ PARALLEL_GC_THREADS=2
 CONCURRENT_GC_THREADS=1
 ```
 
+### Backup Schedule
+
+The image no longer hard codes when backups run. Instead you can control the cron
+schedule with environment variables:
+
+- `CRON_PURGE` &ndash; purge old backups (default `15 08 */7 * *`)
+- `CRON_BACKUP` &ndash; run incremental backups (default `0 * * * *`)
+- `CRON_FULL` &ndash; create a full backup (default `30 05 * * *`)
+
+Set any of these variables to an empty value to disable the corresponding task.
+
 ### AUTO_UPDATE
 
 If set to `true`, the server will automatically update the mods when booting up.

--- a/scripts/setup-cron.sh
+++ b/scripts/setup-cron.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Configure cron schedules for duply backups
+USER=minecraft
+
+BACKUP_CRON="${CRON_BACKUP:-0 * * * *}"
+FULL_CRON="${CRON_FULL:-30 05 * * *}"
+PURGE_CRON="${CRON_PURGE:-15 08 */7 * *}"
+
+add_job() {
+  local schedule="$1"
+  local command="$2"
+  if [ -n "$schedule" ]; then
+    (crontab -u "$USER" -l 2>/dev/null; echo "$schedule $command") \
+      | sort - | uniq - | crontab -u "$USER" -
+  fi
+}
+
+add_job "$PURGE_CRON" "/usr/bin/duply minecraft purgeAuto --force --allow-source-mismatch 2> /var/log/duply.err 1> /var/log/duply.log"
+add_job "$BACKUP_CRON" "/usr/bin/duply minecraft backup now --allow-source-mismatch 2> /var/log/duply.error 1> /var/log/duply.log"
+add_job "$FULL_CRON" "/usr/bin/duply minecraft full now --allow-source-mismatch 2> /var/log/duply.error 1> /var/log/duply.log"
+
+echo "Crontab prepared"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,6 +13,7 @@ chown -R "$USER":"$USER" "$MCDIR"
 
 # ------------------------------------------ THINGS TO DO AS ROOT ------------------------------------------------------
 
+/minecraft/scripts/setup-cron.sh
 crond
 
 echo "Installing MMM"


### PR DESCRIPTION
## Summary
- make duplication/backup cronjobs configurable via environment variables
- add setup-cron script
- document environment variables

## Testing
- `bash -n scripts/setup-cron.sh`
- `bash -n scripts/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_685486edfda0832f873a1e87430f4263